### PR TITLE
Fix type in database.yml development host

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -9,7 +9,7 @@ development:
   database: railsondocker_development
   username: railsondocker
   password: change_me_right_now
-  host: rails7-on-docker-mysql_db_1 
+  host: rails7-on-docker-mysql-db-1
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".


### PR DESCRIPTION
I think there is a typo in the development environment mysql host based on how docker names containers.